### PR TITLE
프론트 토큰 필터 적용

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @LeeJaeDoo @sojeong-park

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")
+
+    implementation("org.apache.commons:commons-pool2")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/com/sp/SpApplication.kt
+++ b/src/main/kotlin/com/sp/SpApplication.kt
@@ -4,10 +4,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.*
 import org.springframework.boot.runApplication
 import org.springframework.cloud.netflix.eureka.*
+import org.springframework.cloud.openfeign.*
+import org.springframework.web.reactive.config.*
 
 @SpringBootApplication
 @EnableEurekaClient
 @ConfigurationPropertiesScan
+@EnableFeignClients
+@EnableWebFlux
 class SpApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/sp/application/model/FrontAccessTokenService.kt
+++ b/src/main/kotlin/com/sp/application/model/FrontAccessTokenService.kt
@@ -1,0 +1,8 @@
+package com.sp.application.model
+
+/**
+ * @author Jaedoo Lee
+ */
+interface FrontAccessTokenService {
+    fun checkMember(accessToken: String): MemberInfo
+}

--- a/src/main/kotlin/com/sp/application/model/FrontAccessTokenService.kt
+++ b/src/main/kotlin/com/sp/application/model/FrontAccessTokenService.kt
@@ -4,5 +4,5 @@ package com.sp.application.model
  * @author Jaedoo Lee
  */
 interface FrontAccessTokenService {
-    fun checkMember(accessToken: String): MemberInfo
+    fun checkMember(accessToken: String): String
 }

--- a/src/main/kotlin/com/sp/application/model/MemberInfo.kt
+++ b/src/main/kotlin/com/sp/application/model/MemberInfo.kt
@@ -1,0 +1,10 @@
+package com.sp.application.model
+
+/**
+ * @author Jaedoo Lee
+ */
+data class MemberInfo(
+    val no: Long,
+    val email: String,
+    val nickname: String
+)

--- a/src/main/kotlin/com/sp/filter/FrontAccessTokenGatewayFilterFactory.kt
+++ b/src/main/kotlin/com/sp/filter/FrontAccessTokenGatewayFilterFactory.kt
@@ -1,0 +1,29 @@
+package com.sp.filter
+
+import com.sp.application.model.FrontAccessTokenService
+import com.sp.filter.extensions.*
+import org.springframework.cloud.gateway.filter.*
+import org.springframework.cloud.gateway.filter.factory.*
+import org.springframework.stereotype.*
+
+/**
+ * @author Jaedoo Lee
+ */
+@Component
+class FrontAccessTokenGatewayFilterFactory(
+    private val frontAccessTokenService: FrontAccessTokenService
+) : AbstractGatewayFilterFactory<Any>() {
+    override fun apply(config: Any?) = GatewayFilter { exchange, chain ->
+        val request = exchange.request
+
+        when (val token = request.headers.getFirst("accessToken")?.takeIf { it.isNotEmpty() }) {
+            null -> chain.filter(exchange.mutate().request(request.mutate().build()).build())
+            else -> frontAccessTokenService.checkMember(token)
+                .let {
+                    chain.filter(exchange.mutate().request(request.mutate()
+                    .header("Member-Info", it.toJson())
+                    .build()).build())
+                }
+        }
+    }
+}

--- a/src/main/kotlin/com/sp/filter/FrontAccessTokenGatewayFilterFactory.kt
+++ b/src/main/kotlin/com/sp/filter/FrontAccessTokenGatewayFilterFactory.kt
@@ -21,7 +21,7 @@ class FrontAccessTokenGatewayFilterFactory(
             else -> frontAccessTokenService.checkMember(token)
                 .let {
                     chain.filter(exchange.mutate().request(request.mutate()
-                    .header("Member-Info", it.toJson())
+                    .header("Member-Info", it)
                     .build()).build())
                 }
         }

--- a/src/main/kotlin/com/sp/filter/extensions/JsonExtensions.kt
+++ b/src/main/kotlin/com/sp/filter/extensions/JsonExtensions.kt
@@ -1,0 +1,27 @@
+package com.sp.filter.extensions
+
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.datatype.jsr310.*
+import com.fasterxml.jackson.datatype.jsr310.deser.*
+import com.fasterxml.jackson.datatype.jsr310.ser.*
+import com.fasterxml.jackson.module.kotlin.*
+import java.time.*
+import java.time.format.*
+
+/**
+ * @author Jaedoo Lee
+ */
+val objectMapper: ObjectMapper = ObjectMapper().apply {
+    registerModule(KotlinModule(nullToEmptyCollection = true, nullToEmptyMap = true, nullisSameAsDefault = true))
+    registerModule(JavaTimeModule().apply {
+        addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+        addDeserializer(
+            LocalDateTime::class.java,
+            LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        )
+    })
+    enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+}
+
+fun Any.toJson(): String = objectMapper.writeValueAsString(this)

--- a/src/main/kotlin/com/sp/infrastructure/configuration/WebFluxConfiguration.kt
+++ b/src/main/kotlin/com/sp/infrastructure/configuration/WebFluxConfiguration.kt
@@ -1,0 +1,28 @@
+package com.sp.infrastructure.configuration
+
+import com.sp.filter.extensions.*
+import org.springframework.context.annotation.*
+import org.springframework.format.*
+import org.springframework.http.codec.*
+import org.springframework.http.codec.json.*
+import org.springframework.web.reactive.config.*
+
+/**
+ * @author Jaedoo Lee
+ */
+@Configuration
+class WebFluxConfiguration : WebFluxConfigurer {
+    override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
+        configurer.defaultCodecs().apply {
+            jackson2JsonEncoder(Jackson2JsonEncoder(objectMapper))
+            jackson2JsonDecoder(Jackson2JsonDecoder(objectMapper))
+        }
+    }
+
+//    override fun addFormatters(registry: FormatterRegistry) {
+//        registry.apply {
+//            addConverter(HttpLocalDateTimeConverter())
+//            addConverter(HttpLocalDateConverter())
+//        }
+//    }
+}

--- a/src/main/kotlin/com/sp/infrastructure/feign/AuthFeignClient.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/AuthFeignClient.kt
@@ -17,6 +17,6 @@ interface AuthFeignClient {
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    fun checkToken(@RequestHeader accessToken: String): MemberInfo
+    fun checkToken(@RequestHeader accessToken: String): String
 
 }

--- a/src/main/kotlin/com/sp/infrastructure/feign/AuthFeignClient.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/AuthFeignClient.kt
@@ -1,0 +1,22 @@
+package com.sp.infrastructure.feign
+
+import com.sp.application.model.*
+import org.springframework.cloud.openfeign.*
+import org.springframework.http.*
+import org.springframework.web.bind.annotation.*
+
+/**
+ * @author Jaedoo Lee
+ */
+@FeignClient("auth-internal", configuration = [FeignConfig::class])
+interface AuthFeignClient {
+
+    @GetMapping(
+        value = ["internal/auth/token/check"],
+        headers = ["Version=1.0"],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun checkToken(@RequestHeader accessToken: String): MemberInfo
+
+}

--- a/src/main/kotlin/com/sp/infrastructure/feign/FeignConfig.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/FeignConfig.kt
@@ -1,0 +1,20 @@
+package com.sp.infrastructure.feign
+
+import com.sp.filter.extensions.*
+import org.springframework.beans.factory.*
+import org.springframework.boot.autoconfigure.http.*
+import org.springframework.context.annotation.*
+import org.springframework.http.converter.*
+import org.springframework.http.converter.json.*
+import kotlin.streams.*
+
+/**
+ * @author Jaedoo Lee
+ */
+@Configuration
+class FeignConfig {
+    @Bean
+    fun messageConverters(converters: ObjectProvider<HttpMessageConverter<*>>): HttpMessageConverters {
+        return HttpMessageConverters(false, converters.orderedStream().toList())
+    }
+}

--- a/src/main/kotlin/com/sp/infrastructure/feign/FeignConfig.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/FeignConfig.kt
@@ -15,6 +15,6 @@ import kotlin.streams.*
 class FeignConfig {
     @Bean
     fun messageConverters(converters: ObjectProvider<HttpMessageConverter<*>>): HttpMessageConverters {
-        return HttpMessageConverters(false, converters.orderedStream().toList())
+        return HttpMessageConverters(true, converters.orderedStream().toList())
     }
 }

--- a/src/main/kotlin/com/sp/infrastructure/feign/adapter/AuthAdapter.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/adapter/AuthAdapter.kt
@@ -16,7 +16,7 @@ class AuthAdapter: FrontAccessTokenService {
     @Autowired
     private lateinit var authFeignClient: AuthFeignClient
 
-    override fun checkMember(accessToken: String): MemberInfo {
+    override fun checkMember(accessToken: String): String {
         return authFeignClient.checkToken(accessToken)
     }
 }

--- a/src/main/kotlin/com/sp/infrastructure/feign/adapter/AuthAdapter.kt
+++ b/src/main/kotlin/com/sp/infrastructure/feign/adapter/AuthAdapter.kt
@@ -1,0 +1,22 @@
+package com.sp.infrastructure.feign.adapter
+
+import com.sp.application.model.*
+import com.sp.infrastructure.feign.*
+import org.springframework.beans.factory.annotation.*
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.*
+
+/**
+ * @author Jaedoo Lee
+ */
+@Component
+class AuthAdapter: FrontAccessTokenService {
+
+    @Lazy
+    @Autowired
+    private lateinit var authFeignClient: AuthFeignClient
+
+    override fun checkMember(accessToken: String): MemberInfo {
+        return authFeignClient.checkToken(accessToken)
+    }
+}

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -33,14 +33,8 @@ spring:
           predicates:
             - Path=/members/**
           filters:
+            - name: FrontAccessToken
             - RewritePath=/(?<segment>.*),     /backend/$\{segment}
-        ### Member Internal ###
-        - id: member-internal
-          uri: lb://member-internal
-          predicates:
-            - Path=/members/**,
-          filters:
-            - RewritePath=/(?<segment>.*),     /internal/$\{segment}
 
 eureka:
   instance:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,15 +1,64 @@
-spring:
-  profiles:
-    active: local # 기본 환경 선택
-
-# local 환경
----
 server:
   port: 8090
 
 spring:
+  profiles:
+    active: alpha # 기본 환경 선택
   application:
     name: gateway
+
+# local 환경
+---
+spring:
+  profiles: local
+  cloud:
+    gateway:
+      globalcors:
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins:
+              - "*"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "*"
+      routes:
+        ### Member Front ###
+        - id: member-front
+          uri: lb://member-front
+          predicates:
+            - Path=/members/**
+          filters:
+            - name: FrontAccessToken
+            - RewritePath=/(?<segment>.*),     /backend/$\{segment}
+
+eureka:
+  instance:
+    prefer-ip-address: true
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+
+auth-internal:
+  ribbon:
+    listOfServers: http://localhost:8083
+
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 4000
+        readTimeout: 4000
+
+# alpha 환경
+---
+spring:
+  profiles: alpha
   cloud:
     gateway:
       globalcors:


### PR DESCRIPTION
client에서 로그인 인증이 필요한 front api 호출 시, 헤더에 토큰값 포함하여 호출하면 front api에 도달하기전
gateway에 FrontAccessTokenGatewayFilterFactory를 먼저 거치고 여기서 auth-internal에 token check api 호출하여
토큰 값이 검증되면 front api로 디코딩된 토큰 값과 함께 front api에 도달,

해당 front api는 인코딩 된 토큰 내 회원 정보를 활용하여 데이터 처리를 할 수 있음